### PR TITLE
订正《通道》《组合挂起函数》以及《协程上下文与调度器》中的一些细节问题

### DIFF
--- a/docs/cancellation-and-timeouts.md
+++ b/docs/cancellation-and-timeouts.md
@@ -79,8 +79,8 @@ main: Now I can quit.
 <!--- TEST -->
 
 一旦 main 函数调用了 `job.cancel`，我们在其它的协程中就看不到任何输出，因为它被取消了。
-这里也有一个可以使 [Job] 挂起的函数 [cancelAndJoin]<!--
--->它合并了对 [cancel][Job.cancel] 以及 [join][Job.join] 的调用。
+这里也有一个可以使 [Job] 挂起的函数 [cancelAndJoin]
+它合并了对 [cancel][Job.cancel] 以及 [join][Job.join] 的调用。
 
 ### 取消协作
 
@@ -121,7 +121,7 @@ fun main() = runBlocking {
 
 > 你可以点击[这里](../core/kotlinx-coroutines-core/test/guide/example-cancel-02.kt)获得完整代码
 
-运行示例代码，并且我们可以看到它连续打印出了 “I'm sleeping” ，甚至在调用取消后，
+运行示例代码，并且我们可以看到它连续打印出了“I'm sleeping” ，甚至在调用取消后，
 任务仍然执行了五次循环迭代并运行到了它结束为止。
 
 <!--- TEST 
@@ -137,8 +137,8 @@ main: Now I can quit.
 ### 使执行计算的代码可被取消
 
 我们有两种方法来使执行计算的代码可以被取消。第一种方法是定期<!--
--->调用挂起函数来检查取消。 对于这种目的 [yield] 是一个好的选择。
-另一种方法是明确的检查取消状态。让我们试试第二种方法。
+-->调用挂起函数来检查取消。对于这种目的 [yield] 是一个好的选择。
+另一种方法是显式的检查取消状态。让我们试试第二种方法。
 
 将前一个示例中的 `while (i < 5)` 替换为 `while (isActive)` 并重新运行它。 
 
@@ -173,8 +173,8 @@ fun main() = runBlocking {
 
 > 你可以点击[这里](../core/kotlinx-coroutines-core/test/guide/example-cancel-03.kt)获得完整代码
 
-你可以看到，现在循环被取消了。[isActive] 是一个可以被使用在<!--
--->[CoroutineScope] 中的扩展属性。
+你可以看到，现在循环被取消了。[isActive] 是一个可以被使用在
+[CoroutineScope] 中的扩展属性。
 
 <!--- TEST
 I'm sleeping 0 ...
@@ -238,7 +238,7 @@ main: Now I can quit.
 
 在前一个例子中任何尝试在 `finally` 块中调用挂起函数的行为都会抛出
 [CancellationException]，因为这里持续运行的代码是可以被取消的。通常，这并不是一个<!--
--->问题，所有良好的关闭操作（关闭一个文件、取消一个任务，或是关闭任何一种<!--
+-->问题，所有良好的关闭操作（关闭一个文件、取消一个任务、或是关闭任何一种<!--
 -->通信通道）通常都是非阻塞的，并且不会调用任何挂起函数。然而，在<!--
 -->真实的案例中，当你需要挂起一个被取消的协程，你可以将相应的代码包装在
 `withContext(NonCancellable) {...}` 中，并使用 [withContext] 函数以及 [NonCancellable] 上下文，见如下示例所示：

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -35,7 +35,7 @@ class ChannelsGuideTest {
 
 ## 通道 (实验性的) 
 
-延期的值提供了一种方便的方法使单个值在多个协程之间进行相互传输。
+延期的值提供了一种便捷的方法使单个值在多个协程之间进行相互传输。
 通道提供了一种在流中传输值的方法。
 
 > 通道在 `kotlinx.coroutines` 中是一个实验性的特性。这些API在 `kotlinx.coroutines`
@@ -136,7 +136,7 @@ Done!
 你可以将生产者抽象成一个函数，并且使通道作为它的参数，但这与<!--
 -->必须从函数中返回结果的常识相违悖。
 
-这里有一个名为 [produce] 的方便的协程构建器，可以很容易的在生产者端正确工作，
+这里有一个名为 [produce] 的便捷的协程构建器，可以很容易的在生产者端正确工作，
 并且我们使用扩展函数 [consumeEach] 在消费者端替代 `for` 循环：
 
 <div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">
@@ -288,7 +288,7 @@ numbersFrom(2) -> filter(2) -> filter(3) -> filter(5) -> filter(7) ...
 下面的例子打印了前十个素数， 
 在主线程的上下文中运行整个管道。直到所有的协程在<!--
 -->该主协程 [runBlocking] 的作用域中被启动完成。
-我们不必使用一个明确的列表来保存所有被我们已经启动的协程。
+我们不必使用一个显式的列表来保存所有被我们已经启动的协程。
 我们使用 [cancelChildren][kotlin.coroutines.CoroutineContext.cancelChildren]
 扩展函数在我们打印了前十个素数以后<!--
 -->来取消所有的子协程。
@@ -345,8 +345,8 @@ fun CoroutineScope.filter(numbers: ReceiveChannel<Int>, prime: Int) = produce<In
 <!--- TEST -->
 
 注意，你可以在标准库中使用
-[`buildIterator`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/build-iterator.html)<!--
--->协程构建器来构建一个相似的管道。 
+[`buildIterator`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/build-iterator.html)
+协程构建器来构建一个相似的管道。 
 使用 `produce` 替换 `buildIterator`、`send` 替换 `yield`、`receive` 替换 `next`、
 `ReceiveChannel` 替换 `Iterator` 来摆脱协程作用域，你将不再需要 `runBlocking`。
 然而，如上所示，如果你在 [Dispatchers.Default] 上下文中运行它，使用通道的管道的好处在于<!--
@@ -392,7 +392,7 @@ fun CoroutineScope.launchProcessor(id: Int, channel: ReceiveChannel<Int>) = laun
 
 </div>
 
-现在让我们启动五个矗立着协程并让它们工作将近一秒。看看发生了什么：
+现在让我们启动五个处理者协程并让它们工作将近一秒。看看发生了什么：
 
 <!--- CLEAR -->
 
@@ -460,7 +460,7 @@ Processor #3 received 10
 
 多个协程可以发送到同一个通道。
 比如说，让我们创建一个字符串的通道，和一个在这个通道中<!--
--->以指定的延迟反复发送一个指定的字符串的挂起函数：
+-->以指定的延迟反复发送一个指定字符串的挂起函数：
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
@@ -525,7 +525,7 @@ BAR!
 
 ### 带缓冲的通道
 
-到目前为止显示的通道都是没有缓冲区的。无缓冲的通道在发送者和接收者相遇时<!--
+到目前为止展示的通道都是没有缓冲区的。无缓冲的通道在发送者和接收者相遇时<!--
 -->传输元素（aka rendezvous（这句话应该是个俚语，意思好像是“又是约会”的意思，不知道怎么翻））。如果发送先被调用，则它将被挂起直到接收被调用，
 如果接收先被调用，它将被挂起直到发送被调用。
 
@@ -579,9 +579,9 @@ Sending 4
 ### 通道是公平的
 
 发送和接收操作是 _公平的_ 并且尊重调用它们的<!--
--->多个协程。它们遵守先进先出原则，看看第一个协程调用 `receive`
+-->多个协程。它们遵守先进先出原则，可以看到第一个协程调用 `receive`
 并得到了元素。在下面的例子中两个协程 “乒” 和 "乓" 都<!-- 
--->从共享的“桌子”通道都接收这个“球”元素。
+-->从共享的“桌子”通道接收到这个“球”元素。
 
 
 <div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">

--- a/docs/composing-suspending-functions.md
+++ b/docs/composing-suspending-functions.md
@@ -31,7 +31,7 @@ class ComposingGuideTest {
 
 ## 组合挂起函数
 
-本节介绍了挂起函数组合的各种方法。
+本节介绍了将挂起函数组合的各种方法。
 
 ### 默认顺序
 
@@ -56,10 +56,10 @@ suspend fun doSomethingUsefulTwo(): Int {
 </div>
 
 
-如果需要按 _顺序_ 调用它们，我们接下来会做什么 -- 首先调用 `doSomethingUsefulOne` _接下来_ 
+如果需要按 _顺序_ 调用它们，我们接下来会做什么--首先调用 `doSomethingUsefulOne` _接下来_ 
 调用 `doSomethingUsefulTwo` 并且计算它们结果的和吗？
 实际上，如果我们要根据第一个函数的结果来决定是否我们需要<!--
--->调用第二个函数或者决定如何调用它，我们就会这样做。
+-->调用第二个函数或者决定如何调用它时，我们就会这样做。
 
 我们使用普通的顺序来进行调用，因为这些代码是运行在协程中的，只要像常规的<!--
 -->代码一样 _顺序_ 都是默认的。下面的示例展示了测量<!--
@@ -115,7 +115,7 @@ Completed in 2017 ms
  
 在概念上，[async] 就类似于 [launch]。它启动了一个单独的协程，这是一个轻量级的线程<!--
 -->并与其它所有的协程一起并发的工作。不同之处在于 `launch` 返回一个 [Job] 并且<!--
--->不附带任何结果值，而 `async` 返回一个 [Deferred] -- 一个轻量级的非阻塞 future，
+-->不附带任何结果值，而 `async` 返回一个 [Deferred] —— 一个轻量级的非阻塞 future，
 这代表了一个将会在稍后提供结果的 promise。你可以使用 `.await()` 在一个延期的值上得到它的最终结果，
 但是 `Deferred` 也是一个 `Job`，所以如果需要的话，你可以取消它。
  
@@ -182,7 +182,7 @@ fun main() = runBlocking<Unit> {
     val time = measureTimeMillis {
         val one = async(start = CoroutineStart.LAZY) { doSomethingUsefulOne() }
         val two = async(start = CoroutineStart.LAZY) { doSomethingUsefulTwo() }
-        // some computation
+        // 执行一些计算
         one.start() // 启动第一个
         two.start() // 启动第二个
         println("The answer is ${one.await() + two.await()}")
@@ -220,8 +220,8 @@ Completed in 1017 ms
 调用 `one`，然后调用 `two`，接下来等待这个协程执行完毕。
 
 注意，如果我们在 `println` 中调用了 [await][Deferred.await] 并且在这个协程中省略调用了
-[start][Job.start]，接下来 [await][Deferred.await] 开始执行协程，我们会得到顺序的<!--
--->行为并且等待执行结束，但这不是惰性启动的预期用例。
+[start][Job.start]，接下来 [await][Deferred.await] 会开始执行协程并且等待协程执行结束，
+因此我们会得到顺序的行为，但这不是惰性启动的预期用例。
 当调用挂起函数计算值的时候
 `async(start = CoroutineStart.LAZY)` 用例是标准的 `lazy` 函数的替换方案。
 
@@ -264,7 +264,7 @@ import kotlinx.coroutines.*
 import kotlin.system.*
 
 //sampleStart
-// note, that we don't have `runBlocking` to the right of `main` in this example
+// 注意，在这个示例中我们在 `main` 函数的右边没有加上 `runBlocking` 
 fun main() {
     val time = measureTimeMillis {
         // 我们可以在协程外面启动异步执行
@@ -314,8 +314,8 @@ Completed in 1085 ms
 
 考虑一下如果 `val one = somethingUsefulOneAsync()` 这一行和 `one.await()` 表达式这里在代码中有逻辑错误，
 并且程序抛出了异常以及程序在操作的过程中被中止，将会发生什么。
-通常情况下，一个全局的异常处理者会捕获这个异常，将异常打印成日记并报告给开发者，但是该程序
-否则将会继续执行其它操作。但是这里我们的 `somethingUsefulOneAsync` 仍然在后台执行，
+通常情况下，一个全局的异常处理者会捕获这个异常，将异常打印成日记并报告给开发者，但是反之<!--
+-->该程序将会继续执行其它操作。但是这里我们的 `somethingUsefulOneAsync` 仍然在后台执行，
 尽管如此，启动它的那次操作也会被终止。这个程序将不会进行结构性<!--
 -->并发，如下一小节所示。
 
@@ -339,7 +339,7 @@ suspend fun concurrentSum(): Int = coroutineScope {
 </div>
 
 这种情况下，如果在 `concurrentSum` 函数内部发生了错误，并且它抛出了一个异常，
-所有在作用域中启动的协程将会被取消。
+所有在作用域中启动的协程都将会被取消。
 
 <!--- CLEAR -->
 
@@ -388,7 +388,7 @@ Completed in 1017 ms
 
 <!--- TEST ARBITRARY_TIME -->
 
-取消始终通过协程的层次结构来进行传播：
+取消始终通过协程的层次结构来进行传递：
 
 <!--- CLEAR -->
 

--- a/docs/coroutine-context-and-dispatchers.md
+++ b/docs/coroutine-context-and-dispatchers.md
@@ -39,7 +39,7 @@ class DispatchersGuideTest {
 
 协程总是运行在一些以
 [CoroutineContext](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.coroutines/-coroutine-context/) 
-类型为代表的上下文中，它们被定义在了 Kotlin 的标准库中。
+类型为代表的上下文中，它们被定义在了 Kotlin 的标准库里。
 
 协程上下文是各种不同元素的集合。其中主元素是协程中的 [Job]，
 我们在前面的文档中见过它以及它的调度器，而本文将对它进行介绍。
@@ -171,8 +171,8 @@ main runBlocking: After delay in thread main
 
 协程可以在一个线程上挂起并恢复其它线程。
 甚至一个单线程的调度器是非常难以<!--
--->弄清楚协程何时，在哪里，正在做什么的。使用通常的方法来调试应用程序是让
-线程在每一个日志文件的日志声明中打印线程的名字。这种特性在日志框架中是<!--
+-->弄清楚协程何时，在哪里，正在做什么的。使用通常的方法来调试应用程序是让<!--
+-->线程在每一个日志文件的日志声明中打印线程的名字。这种特性在日志框架中是<!--
 -->普遍受支持的。使用协程时，单独的线程名称不会给出很多上下文，所以
 `kotlinx.coroutines` 包含了调试工具来让它更简单。
 
@@ -268,7 +268,7 @@ fun main() {
 <!--- TEST -->
 
 注意，在这个例子中，当我们不再需要某个在 [newSingleThreadContext] 中创建的线程的时候，
-它使用了标准库中的 Kotlin 标准库中的 `use` 函数来释放该线程。
+它使用了 Kotlin 标准库中的 `use` 函数来释放该线程。
 
 ### 上下文中的任务
 
@@ -408,9 +408,9 @@ Now processing of the request is complete
 
 协程日志会频繁记录的时候以及当你只是需要来自相同协程的关联日志记录，
 自动分配 id 是非常棒的。然而，当协程与执行一个明确的请求<!--
--->或与执行一些显式的后台任务有关的时候，对于调试的目的给它明确的命名是更好的。
-[CoroutineName] 上下文元素可以给线程像给函数命名一样命名。它将显示线程的名字<!--
--->当协程被执行且 [调试模式](#debugging-coroutines-and-threads) 被开启时。
+-->或与执行一些显式的后台任务有关的时候，出于调试的目的给它明确的命名是更好的。
+[CoroutineName] 上下文元素可以给线程像给函数命名一样命名。它在协程被执行且
+[调试模式](#debugging-coroutines-and-threads)被开启时将显示线程的名字。
 
 下面的例子演示了这一概念：
 
@@ -458,7 +458,7 @@ fun main() = runBlocking(CoroutineName("main")) {
 ### 组合上下文中的元素
 
 有时我们需要在协程上下文中定义多个元素。我们可以使用 `+` 操作符来实现。
-比如说，我们可以明确的指定一个调度器来启动协程并且同时明确指定<!--
+比如说，我们可以显式地指定一个调度器来启动协程并且同时显式指定<!--
 -->一个命名： 
 
 <div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">
@@ -629,12 +629,12 @@ Destroying activity!
 
 ### 线程局部的数据
 
-有时能够传递一些线程局部的数据很方便，但是，对于协程来说, 它们不受<!--
+有时能够传递一些线程局部的数据很方便，但是，对于协程来说，它们不受<!--
 -->任何特定线程的约束，所以很难手动的去实现它并且不写出大量的样板代码。
 
-对于 [`ThreadLocal`](https://docs.oracle.com/javase/8/docs/api/java/lang/ThreadLocal.html)，
-[asContextElement] 扩展函数在这里拯救了一切。它创建了额外的上下文元素，
-它保留给定 `ThreadLocal` 的值，并在每次协同程序切换其上下文时恢复它。
+[`ThreadLocal`](https://docs.oracle.com/javase/8/docs/api/java/lang/ThreadLocal.html)，
+[asContextElement] 扩展函数在这里会充当救兵。它创建了额外的上下文元素，
+且保留给定 `ThreadLocal` 的值，并在每次协同程序切换其上下文时恢复它。
 
 它很容易在下面的代码中演示：
 
@@ -689,7 +689,7 @@ Post-main, current thread: Thread[main @coroutine#1,5,main], thread local value:
 -->可能的对这个可变的域进行的并发的修改。
 
 对于高级的使用，例如，那些在内部使用线程局部传递数据的<!--
--->用于与日志记录MDC集成，以及事务上下文或任何其他库，文件中应该实现
+-->用于与日志记录 MDC 集成，以及事务上下文或任何其他库，文件中应该实现
 [ThreadContextElement] 接口。
 
 <!--- MODULE kotlinx-coroutines-core -->


### PR DESCRIPTION
修改了一些标点符号错误，部分文字表述，以及某些漏翻的代码注释