### PR TITLE
将《通道》中的“producer”的翻译统一为“生产者”

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -405,7 +405,7 @@ fun main() = runBlocking<Unit> {
     val producer = produceNumbers()
     repeat(5) { launchProcessor(it, producer) }
     delay(950)
-    producer.cancel() // 取消协程处理器从而将它们全部杀死
+    producer.cancel() // 取消协程处理者从而将它们全部杀死
 //sampleEnd
 }
 
@@ -428,7 +428,7 @@ fun CoroutineScope.launchProcessor(id: Int, channel: ReceiveChannel<Int>) = laun
 
 > 你可以点击[这里](../core/kotlinx-coroutines-core/test/guide/example-channel-06.kt)获得完整代码
 
-该输出将类似于如下所示，尽管接收的是处理器的 id
+该输出将类似于如下所示，尽管接收的是处理者的 id
 但每个整数也许会不同：
 
 ```
@@ -451,8 +451,8 @@ Processor #3 received 10
 
 还有，注意我们如何使用 `for` 循环显式迭代通道以在 `launchProcessor` 代码中执行扇出。
 与 `consumeEach` 不同，这个 `for` 循环是安全完美地使用多个协程的。如果其中一个处理者<!--
--->协程执行失败，其它的处理器协程仍然会继续处理通道，而通过 `consumeEach`
-编写的处理器始终在正常或非正常完成时消耗（取消）底层通道。
+-->协程执行失败，其它的处理者协程仍然会继续处理通道，而通过 `consumeEach`
+编写的处理者始终在正常或非正常完成时消耗（取消）底层通道。
 
 ### 扇入
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -375,7 +375,7 @@ fun CoroutineScope.produceNumbers() = produce<Int> {
 
 </div>
 
-接下来我们可以得到几个处理者协程。在这个示例中，它们只是打印它们的 id 和<!--
+接下来我们可以得到几个生产者协程。在这个示例中，它们只是打印它们的 id 和<!--
 -->接收到的数字：
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
@@ -390,7 +390,7 @@ fun CoroutineScope.launchProcessor(id: Int, channel: ReceiveChannel<Int>) = laun
 
 </div>
 
-现在让我们启动五个处理者协程并让它们工作将近一秒。看看发生了什么：
+现在让我们启动五个生产者协程并让它们工作将近一秒。看看发生了什么：
 
 <!--- CLEAR -->
 
@@ -405,7 +405,7 @@ fun main() = runBlocking<Unit> {
     val producer = produceNumbers()
     repeat(5) { launchProcessor(it, producer) }
     delay(950)
-    producer.cancel() // 取消协程处理者从而将它们全部杀死
+    producer.cancel() // 取消协程生产者从而将它们全部杀死
 //sampleEnd
 }
 
@@ -428,7 +428,7 @@ fun CoroutineScope.launchProcessor(id: Int, channel: ReceiveChannel<Int>) = laun
 
 > 你可以点击[这里](../core/kotlinx-coroutines-core/test/guide/example-channel-06.kt)获得完整代码
 
-该输出将类似于如下所示，尽管接收的是处理者的 id
+该输出将类似于如下所示，尽管接收的是生产者的 id
 但每个整数也许会不同：
 
 ```
@@ -446,13 +446,13 @@ Processor #3 received 10
 
 <!--- TEST lines.size == 10 && lines.withIndex().all { (i, line) -> line.startsWith("Processor #") && line.endsWith(" received ${i + 1}") } -->
 
-注意，取消生产者协程并关闭它的通道，因此通过正在执行的处理者协程通道来<!--
+注意，取消生产者协程并关闭它的通道，因此通过正在执行的生产者协程通道来<!--
 -->终止迭代。
 
 还有，注意我们如何使用 `for` 循环显式迭代通道以在 `launchProcessor` 代码中执行扇出。
-与 `consumeEach` 不同，这个 `for` 循环是安全完美地使用多个协程的。如果其中一个处理者<!--
--->协程执行失败，其它的处理者协程仍然会继续处理通道，而通过 `consumeEach`
-编写的处理者始终在正常或非正常完成时消耗（取消）底层通道。
+与 `consumeEach` 不同，这个 `for` 循环是安全完美地使用多个协程的。如果其中一个生产者<!--
+-->协程执行失败，其它的生产者协程仍然会继续处理通道，而通过 `consumeEach`
+编写的生产者始终在正常或非正常完成时消耗（取消）底层通道。
 
 ### 扇入
 

--- a/docs/select-expression.md
+++ b/docs/select-expression.md
@@ -43,13 +43,13 @@ select 表达式可以同时等待多个挂起函数，并 _选择_
 
 ### 在通道中 select
 
-我们现在有两个字符串生产者：`fizz` 和 `buzz` 。其中 `fizz` 每300毫秒生成一个 “Fizz” 字符串：
+我们现在有两个字符串生产者：`fizz` 和 `buzz` 。其中 `fizz` 每 300 毫秒生成一个“Fizz”字符串：
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 
 ```kotlin
 fun CoroutineScope.fizz() = produce<String> {
-    while (true) { // 每300毫秒发送一个 "Fizz"
+    while (true) { // 每 300 毫秒发送一个 "Fizz"
         delay(300)
         send("Fizz")
     }
@@ -64,7 +64,7 @@ fun CoroutineScope.fizz() = produce<String> {
 
 ```kotlin
 fun CoroutineScope.buzz() = produce<String> {
-    while (true) { // 每 500 毫秒发送一个 "Buzz!"
+    while (true) { // 每 500 毫秒发送一个"Buzz!"
         delay(500)
         send("Buzz!")
     }
@@ -94,7 +94,7 @@ suspend fun selectFizzBuzz(fizz: ReceiveChannel<String>, buzz: ReceiveChannel<St
 
 </div>
 
-让我们运行代码7次：
+让我们运行代码 7 次：
 
 <!--- CLEAR -->
 


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [kotlin-web-site-cn#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [ ] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [ ] 阅读过 Kotlin 参考的大部分章节
- [ ] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [ ] 翻译中所用术语均与术语表中一致
- [ ] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [ ] 正文与注释中的标点均已使用全角
- [ ] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [ ] 英文与标点之间未留空格
- [ ] 行级对照，中文句子中间断行处已使用 HTML 注释

1.将《通道》中的“producer”的翻译统一为“生产者”
2.修复一些《Select 表达式》中的一些空格问题
