### PR TITLE
修改一处翻译错误, 并增加额外解释

### DIFF
--- a/docs/composing-suspending-functions.md
+++ b/docs/composing-suspending-functions.md
@@ -426,8 +426,7 @@ suspend fun failedConcurrentSum(): Int = coroutineScope {
 
 > 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-compose-06.kt)获取完整代码。
 
-注意，当任意一个子协程失败的时候，第一个 `async` 以及等待中的父协程都会被取消
-（即 `two`）：
+注意，当任意一个子协程抛出异常的时候，等待中的父协程(本例中`coroutineScope`)、第一个 `async` 以及第二个 `async` (即 `two`) 都会被取消
 ```text
 Second child throws an exception
 First child was cancelled


### PR DESCRIPTION
英文原文为:
Note how both the first async and the awaiting parent are cancelled on failure of one of the children (namely, two):

- [x ] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [x ] 阅读过 Kotlin 参考的大部分章节
- [x ] 每一句都已经过谷歌机翻作为参考
- [x ] 每一句都已经过搜狗机翻作为参考
- [x ] 翻译中所用术语均与术语表中一致
- [x ] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [x ] 正文与注释中的标点均已使用全角
- [x ] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [x ] 英文与标点之间未留空格
- [x ] 行级对照，中文句子中间断行处已使用 HTML 注释
