### PR TITLE
统一《异步流》中的一处表述与其他文档一致

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -154,7 +154,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-03.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-03.kt)获取完整代码。
 
 这段代码将会在等待一秒之后打印数字。
 
@@ -199,7 +199,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-04.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-04.kt)获取完整代码。
 
 这段代码在不阻塞主线程的情况下每等待 100 毫秒打印一个数字。在主线程中运行一个<!--
 -->单独的协程每 100 毫秒打印一次 “I'm not blocked” 已经经过了验证。
@@ -259,7 +259,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-05.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-05.kt)获取完整代码。
 
 打印如下：
 
@@ -318,7 +318,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-06.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-06.kt)获取完整代码。
 
 注意，在 `foo()` 函数中流仅发射两个数字，产生以下输出：
 
@@ -358,7 +358,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-07.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-07.kt)获取完整代码。
  
 <!--- TEST
 1
@@ -403,7 +403,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-08.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-08.kt)获取完整代码。
 
 它产生以下三行，每一行每秒出现一次：
 
@@ -449,7 +449,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-09.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-09.kt)获取完整代码。
 
 这段代码的输出如下：
 
@@ -498,7 +498,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-10.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-10.kt)获取完整代码。
 
 这段代码的输出清楚地表明，`numbers()` 函数中对 `flow {...}` 函数体的执行在<!--
 -->发射出第二个数字后停止：
@@ -540,7 +540,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-11.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-11.kt)获取完整代码。
 
 打印单个数字：
 
@@ -585,7 +585,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-12.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-12.kt)获取完整代码。
 
 执行：
 
@@ -653,7 +653,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-13.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-13.kt)获取完整代码。
 
 运行这段代码：
 
@@ -704,7 +704,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-14.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-14.kt)获取完整代码。
 
 这段代码产生如下的异常：
 
@@ -751,7 +751,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-15.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-15.kt)获取完整代码。
   
 注意，当收集发生在主线程中，`flow { ... }` 是如何在后台线程中工作的：
   
@@ -805,7 +805,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-16.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-16.kt)获取完整代码。
 
 它会产生这样的结果，整个收集过程大约需要 1200 毫秒（3 个数字，每个花费 400 毫秒）：
 
@@ -852,7 +852,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-17.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-17.kt)获取完整代码。
 
 它产生了相同的数字，只是更快了，由于我们高效地创建了处理流水线，
 仅仅需要等待第一个数字产生的 100 毫秒以及处理每个数字各需<!--
@@ -907,7 +907,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-18.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-18.kt)获取完整代码。
 
 我们看到，虽然第一个数字仍在处理中，但第二个和第三个数字已经产生，因此<!--
 -->第二个是 _conflated_ ，只有最新的（第三个）被交付给收集器：
@@ -958,7 +958,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-19.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-19.kt)获取完整代码。
  
 由于 [collectLatest] 的函数体需要花费 300 毫秒，但是新值每 100 秒发射一次，我们看到该代码块<!-- 
 -->对每个值运行，但是只收集最后一个值：
@@ -1000,7 +1000,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-20.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-20.kt)获取完整代码。
 
 示例打印如下：
 
@@ -1047,7 +1047,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-21.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-21.kt)获取完整代码。
 
 <!--- TEST ARBITRARY_TIME
 1 -> one at 437 ms from start
@@ -1078,7 +1078,7 @@ fun main() = runBlocking<Unit> {
 
 </div>
 
-> 你可以从[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-22.kt)获取完整代码。
+> 可以在[这里](../kotlinx-coroutines-core/jvm/test/guide/example-flow-22.kt)获取完整代码。
 
 我们得到了完全不同的输出，其中，`nums` 或 `strs` 流中的每次发射都会打印一行：
 


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [kotlin-web-site-cn#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [x] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [x] 阅读过 Kotlin 参考的大部分章节
- [x] 每一句都已经过谷歌机翻作为参考
- [x] 每一句都已经过搜狗机翻作为参考
- [x] 翻译中所用术语均与术语表中一致
- [x] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [x] 正文与注释中的标点均已使用全角
- [x] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [x] 英文与标点之间未留空格
- [x] 行级对照，中文句子中间断行处已使用 HTML 注释

统一《异步流》中的一处表述与其他文档一致