### PR TITLE
清理所有有英文的协程文档

### DIFF
--- a/docs/coroutine-context-and-dispatchers.md
+++ b/docs/coroutine-context-and-dispatchers.md
@@ -170,14 +170,14 @@ Kotlin 插件的协程调试器简化了 IntelliJ IDEA 中的协程调试.
 
 ![Debugging coroutines](images/coroutine-idea-debugging-1.png)
 
-使用协程调试器，您可以：
+使用协程调试器，你可以：
 * 检查每个协程的状态。
 * 查看正在运行的与挂起的的协程的局部变量以及捕获变量的值。
 * 查看完整的协程创建栈以及协程内部的调用栈。栈包含所有<!--
--->带有变量的栈帧, 甚至包含那些在标准调试期间会丢失的栈帧。
+-->带有变量的栈帧，甚至包含那些在标准调试期间会丢失的栈帧。
 * 获取包含每个协程的状态以及栈信息的完整报告。要获取它，请右键单击 **Coroutines** 选项卡，然后点击 **Get Coroutines Dump**。
 
-要开始协程调试，您只需要设置断点并在调试模式下运行应用程序即可。
+要开始协程调试，你只需要设置断点并在调试模式下运行应用程序即可。
 
 在这篇[教程](https://kotlinlang.org/docs/tutorials/coroutines/debug-coroutines-with-idea.html)中学习更多的协程调试知识。
 
@@ -529,8 +529,8 @@ class Activity {
 
 </div>
 
-Now, we can launch coroutines in the scope of this `Activity` using the defined `scope`.
-For the demo, we launch ten coroutines that delay for a different time:
+现在，我们可以使用定义的 `scope` 在这个 `Activity` 的作用域内启动协程。
+对于该示例，我们启动了十个协程，它们会延迟不同的时间：
 
 <div class="sample" markdown="1" theme="idea" data-highlight-only>
 

--- a/docs/coroutine-context-and-dispatchers.md
+++ b/docs/coroutine-context-and-dispatchers.md
@@ -161,25 +161,25 @@ main runBlocking: After delay in thread main
 
 #### 用 IDEA 调试
 
-The Coroutine Debugger of the Kotlin plugin simplifies debugging coroutines in IntelliJ IDEA.
+Kotlin 插件的协程调试器简化了 IntelliJ IDEA 中的协程调试.
 
-> Debugging works for versions 1.3.8 or later of `kotlinx-coroutines-core`.
+> 调试适用于 1.3.8 或更高版本的 `kotlinx-coroutines-core`。
 
-The **Debug** tool window contains the **Coroutines** tab. In this tab, you can find information about both currently running and suspended coroutines. 
-The coroutines are grouped by the dispatcher they are running on.
+**调试**工具窗口包含 **Coroutines** 标签。在这个标签中，你可以同时找到运行中与已挂起的协程的相关信息。
+这些协程以它们所运行的调度器进行分组。
 
 ![Debugging coroutines](images/coroutine-idea-debugging-1.png)
 
-With the coroutine debugger, you can:
-* Check the state of each coroutine.
-* See the values of local and captured variables for both running and suspended coroutines.
-* See a full coroutine creation stack, as well as a call stack inside the coroutine. The stack includes all frames with 
-variable values, even those that would be lost during standard debugging.
-* Get a full report that contains the state of each coroutine and its stack. To obtain it, right-click inside the **Coroutines** tab, and then click **Get Coroutines Dump**.
+使用协程调试器，您可以：
+* 检查每个协程的状态。
+* 查看正在运行的与挂起的的协程的局部变量以及捕获变量的值。
+* 查看完整的协程创建栈以及协程内部的调用栈。栈包含所有<!--
+-->带有变量的栈帧, 甚至包含那些在标准调试期间会丢失的栈帧。
+* 获取包含每个协程的状态以及栈信息的完整报告。要获取它，请右键单击 **Coroutines** 选项卡，然后点击 **Get Coroutines Dump**。
 
-To start coroutine debugging, you just need to set breakpoints and run the application in debug mode.
+要开始协程调试，您只需要设置断点并在调试模式下运行应用程序即可。
 
-Learn more about coroutines debugging in the [tutorial](https://kotlinlang.org/docs/tutorials/coroutines/debug-coroutines-with-idea.html).
+在这篇[教程](https://kotlinlang.org/docs/tutorials/coroutines/debug-coroutines-with-idea.html)中学习更多的协程调试知识。
 
 #### 用日志调试
 

--- a/docs/exception-handling.md
+++ b/docs/exception-handling.md
@@ -78,30 +78,30 @@ Caught ArithmeticException
 
 ### CoroutineExceptionHandler
 
-It is possible to customize the default behavior of printing **uncaught** exceptions to the console.
-[CoroutineExceptionHandler] context element on a _root_ coroutine can be used as generic `catch` block for
-this root coroutine and all its children where custom exception handling may take place.
-It is similar to [`Thread.uncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setUncaughtExceptionHandler(java.lang.Thread.UncaughtExceptionHandler)).
-You cannot recover from the exception in the `CoroutineExceptionHandler`. The coroutine had already completed
-with the corresponding exception when the handler is called. Normally, the handler is used to
-log the exception, show some kind of error message, terminate, and/or restart the application.
+将**未捕获**异常打印到控制台的默认行为是可自定义的。
+*根*协程中的 [CoroutineExceptionHandler] 上下文元素可以被用于这个根协程<!--
+-->通用的 `catch` 块，及其所有可能自定义了异常处理的子协程。
+它类似于 [`Thread.uncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setUncaughtExceptionHandler(java.lang.Thread.UncaughtExceptionHandler)) 。
+你无法从 `CoroutineExceptionHandler` 的异常中恢复。当调用处理者的时候，协程已经完成<!--
+-->并带有相应的异常。通常，该处理者用于<!--
+-->记录异常，显示某种错误消息，终止和（或）重新启动应用程序。
 
 在 JVM 中可以重定义一个全局的异常处理者来将所有的协程通过
 [`ServiceLoader`](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) 注册到 [CoroutineExceptionHandler]。
 全局异常处理者就如同
 [`Thread.defaultUncaughtExceptionHandler`](https://docs.oracle.com/javase/8/docs/api/java/lang/Thread.html#setDefaultUncaughtExceptionHandler(java.lang.Thread.UncaughtExceptionHandler)) 
 一样，在没有更多的指定的异常处理者被注册的时候被使用。
-在 Android 中， `uncaughtExceptionPreHandler` 被设置在全局协程异常处理者中。
+在 Android 中，`uncaughtExceptionPreHandler` 被设置在全局协程异常处理者中。
 
-`CoroutineExceptionHandler` is invoked only on **uncaught** exceptions &mdash; exceptions that were not handled in any other way.
-In particular, all _children_ coroutines (coroutines created in the context of another [Job]) delegate handling of
-their exceptions to their parent coroutine, which also delegates to the parent, and so on until the root,
-so the `CoroutineExceptionHandler` installed in their context is never used. 
-In addition to that, [async] builder always catches all exceptions and represents them in the resulting [Deferred] object, 
-so its `CoroutineExceptionHandler` has no effect either.
+`CoroutineExceptionHandler` 仅在**未捕获**的异常上调用 &mdash; 没有以其他任何方式处理的异常。
+特别是，所有*子*协程（在另一个 [Job] 上下文中创建的协程）委托<!--
+它们的父协程处理它们的异常，然后它们也委托给其父协程，以此类推直到根协程，
+因此永远不会使用在其上下文中设置的 `CoroutineExceptionHandler`。
+除此之外，[async] 构建器始终会捕获所有异常并将其表示在结果 [Deferred] 对象中，
+因此它的 `CoroutineExceptionHandler` 也无效。
 
-> Coroutines running in supervision scope do not propagate exceptions to their parent and are
-excluded from this rule. A further [Supervision](#supervision) section of this document gives more details.  
+> 在监督作用域内运行的协程不会将异常传播到其父协程，并且<!--
+-->会从此规则中排除。本文档的另一个小节——[监督](#监督)提供了更多细节。
 
 <div class="sample" markdown="1" theme="idea" data-min-compiler-version="1.3">
 
@@ -113,10 +113,10 @@ fun main() = runBlocking {
     val handler = CoroutineExceptionHandler { _, exception -> 
         println("CoroutineExceptionHandler got $exception") 
     }
-    val job = GlobalScope.launch(handler) { // root coroutine, running in GlobalScope
+    val job = GlobalScope.launch(handler) { // 根协程，运行在 GlobalScope 中
         throw AssertionError()
     }
-    val deferred = GlobalScope.async(handler) { // also root, but async instead of launch
+    val deferred = GlobalScope.async(handler) { // 同样是根协程，但使用 async 代替了 launch
         throw ArithmeticException() // 没有打印任何东西，依赖用户去调用 deferred.await()
     }
     joinAll(job, deferred)


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [kotlin-web-site-cn#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [x] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [x] 阅读过 Kotlin 参考的大部分章节
- [x] 每一句都已经过谷歌机翻作为参考
- [x] 每一句都已经过搜狗机翻作为参考
- [x] 翻译中所用术语均与术语表中一致
- [x] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [x] 正文与注释中的标点均已使用全角
- [x] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [x] 英文与标点之间未留空格
- [x] 行级对照，中文句子中间断行处已使用 HTML 注释

清理所有有英文的协程文档