### PR TITLE
[勘误]修正Flow中关于flatMapConcat﻿的表述

### DIFF
--- a/docs/topics/flow.md
+++ b/docs/topics/flow.md
@@ -1041,9 +1041,7 @@ as such, there is a family of flattening operators on flows.
 
 ### flatMapConcat
 
-Concatenating mode is implemented by [flatMapConcat] and [flattenConcat] operators. They are the most direct
-analogues of the corresponding sequence operators. They wait for the inner flow to complete before
-starting to collect the next one as the following example shows:
+连接模式由 [flatMapConcat] 与 [flattenConcat] 操作符实现。它们是相应序列操作符最相近的类似物。它们在等待内部流完成之后开始收集下一个值，如下面的示例所示：
 
 ```kotlin
 import kotlinx.coroutines.*


### PR DESCRIPTION
此处原文参考官网：https://kotlinlang.org/docs/flow.html#flatmapconcat
> They wait for the inner flow to complete before starting to collect the next one as the following example shows:

对应Google翻译：
> 他们等待内部流程完成，然后开始收集下一个流程，如以下示例所示：

所以此处应该翻译为：
> 它们在等待内部流完成**之后**开始收集下一个值，如下面的示例所示：

而非kotlincn.net官网目前的翻译（https://www.kotlincn.net/docs/reference/coroutines/flow.html）：
> 它们在等待内部流完成**之前**开始收集下一个值，如下面的示例所示：

<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [kotlin-web-site-cn#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [X] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [X] 阅读过 Kotlin 参考的大部分章节
- [X] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [X] 翻译中所用术语均与术语表中一致
- [X] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [X] 正文与注释中的标点均已使用全角
- [X] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [X] 英文与标点之间未留空格
- [X] 行级对照，中文句子中间断行处已使用 HTML 注释
